### PR TITLE
Add a script to manually sync SmartAPI outside of server

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format:check": "npm run prettier -- --check",
     "lint": "npm run format:check",
     "test": "lerna run test",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "smartapi_sync": "SYNC_AND_EXIT=true node ./scripts/smartapi_sync.js"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.29.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "npm run format:check",
     "test": "lerna run test",
     "prepare": "npm run compile",
-    "smartapi_sync": "SYNC_AND_EXIT=true node ./scripts/smartapi_sync.js"
+    "smartapi_sync": "cd packages/@biothings-explorer/bte-trapi && npm run smartapi_sync"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.29.3",

--- a/scripts/smartapi_sync.js
+++ b/scripts/smartapi_sync.js
@@ -1,2 +1,0 @@
-sync = require("../packages/@biothings-explorer/bte-trapi/src/controllers/cron/update_local_smartapi.js");
-sync();

--- a/scripts/smartapi_sync.js
+++ b/scripts/smartapi_sync.js
@@ -1,0 +1,2 @@
+sync = require("../packages/@biothings-explorer/bte-trapi/src/controllers/cron/update_local_smartapi.js");
+sync()

--- a/scripts/smartapi_sync.js
+++ b/scripts/smartapi_sync.js
@@ -1,2 +1,2 @@
 sync = require("../packages/@biothings-explorer/bte-trapi/src/controllers/cron/update_local_smartapi.js");
-sync()
+sync();


### PR DESCRIPTION
*(addresses biothings/Biothings_Explorer_TRAPI#271)*

Adds a script `npm run smartapi_sync` to manually sync the latest `smartapi_specs.json` and `predicates.json` outside of running the server.